### PR TITLE
Fix syntax highlighting (on Mac).

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.extraPaths": [ "/var/tmp/sage-10.3-current/venv/lib/python3.11/site-packages" ],
+}


### PR DESCRIPTION
Add the search path to Pylance can resolve the issue.